### PR TITLE
Add MVP scaffolding for Buffoon agent platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+BUFFOON_RESULT_PATH=/tmp/buffoon-result.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Node
+node_modules/
+.next/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+
+# Docker
+*.log
+
+# Sandbox artifacts
+sandbox/storage/sessions/
+/tmp/buffoon-result.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
 # Buffoon
+
+Buffoon is an agent orchestration platform that provisions sandbox containers, coordinates FastAPI services, and surfaces results through a Next.js dashboard built with the Geist design system.
+
+## Architecture
+
+- **Frontend**: Next.js 13 + TypeScript UI using Geist components for accessible, responsive layouts.
+- **Backend**: FastAPI application with structured logging, background task execution, and in-memory repositories for the MVP.
+- **Sandbox**: Python 3.11 container that simulates agent execution and writes structured JSON artifacts.
+- **Shared packages**: Reusable TypeScript utility and type packages for consistent client/server contracts.
+
+## Getting Started
+
+1. Copy `.env.example` to `.env` and adjust values as required.
+2. Install dependencies and run the development stack:
+
+   ```bash
+   npm --prefix frontend install
+   pip install -r backend/requirements.txt
+   uvicorn backend.main:app --reload
+   npm --prefix frontend run dev
+   ```
+
+   Or start everything using Docker Compose:
+
+   ```bash
+   ./scripts/dev.sh
+   ```
+
+## API Overview
+
+- `GET /health/` — health check endpoint.
+- `POST /tasks` — queue a new task for sandbox execution.
+- `GET /tasks` — list all tasks with their current statuses.
+- `GET /tasks/{task_id}` — inspect an individual task.
+- `GET /agents` — fetch agent runtime state and logs.
+- `GET /agents/{agent_id}` — inspect a single agent session.
+
+## Frontend Pages
+
+- `/` — hero page with quick task submission.
+- `/tasks` — console with live task list and agent dashboards.
+- `/agents/[agentId]` — detailed view for an agent session with VNC endpoint metadata.
+
+## Scripts
+
+- `scripts/dev.sh` — run docker-compose dev stack with live reload.
+- `scripts/build.sh` — build production images.
+- `scripts/deploy.sh` — launch the stack in detached mode.
+
+## Licensing & Attribution
+
+- Donations: ETH/BSC `0xBFD25B75E9a742cEC6ea68D06d631f6EF14Cfa82`, TRX `TRat8qcN5zBQL11SMYWpQKD3EGJacMMy2m`, BTC `bc1qww4ky9sj90k93amwmmsulx2hnvlt9fvktw9d05`
+- Copyright: [https://t.me/likhonsheikh](https://t.me/likhonsheikh)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/buffoon/__init__.py
+++ b/backend/buffoon/__init__.py
@@ -1,0 +1,1 @@
+"""Buffoon backend package."""

--- a/backend/buffoon/backend_utils/logger.py
+++ b/backend/buffoon/backend_utils/logger.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from typing import Any, Dict
+
+from loguru import logger
+
+_LOGGER_CONFIGURED = False
+
+
+def configure_logging() -> None:
+    global _LOGGER_CONFIGURED
+    if _LOGGER_CONFIGURED:
+        return
+
+    logger.remove()
+    logger.add(
+        sys.stdout,
+        colorize=True,
+        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan> - <level>{message}</level>",
+    )
+    _LOGGER_CONFIGURED = True
+
+
+def get_logger() -> Any:
+    configure_logging()
+    return logger
+
+
+def structured_log(message: str, **context: Dict[str, Any]) -> None:
+    log = get_logger()
+    log.bind(**context).info(message)

--- a/backend/buffoon/routers/agents.py
+++ b/backend/buffoon/routers/agents.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+from ..schemas.AgentState import AgentState
+from ..services.agent_state_store import get_agent_state_store
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+@router.get("/", response_model=list[AgentState])
+async def list_agents() -> list[AgentState]:
+    store = get_agent_state_store()
+    state_map = await store.list()
+    return list(state_map.values())
+
+
+@router.get("/{agent_id}", response_model=AgentState)
+async def get_agent(agent_id: str) -> AgentState:
+    store = get_agent_state_store()
+    state = await store.get(agent_id)
+    if not state:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+    return state

--- a/backend/buffoon/routers/health.py
+++ b/backend/buffoon/routers/health.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+@router.get("/")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/buffoon/routers/tasks.py
+++ b/backend/buffoon/routers/tasks.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, status
+
+from ..schemas.TaskRequest import TaskRequest, TaskResponse
+from ..services.sandbox_manager import get_sandbox_manager
+from ..services.task_repository import get_task_repository
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+@router.get("/", response_model=list[TaskResponse])
+async def list_tasks() -> list[TaskResponse]:
+    repository = get_task_repository()
+    return await repository.list_tasks()
+
+
+@router.get("/{task_id}", response_model=TaskResponse)
+async def get_task(task_id: str) -> TaskResponse:
+    repository = get_task_repository()
+    task = await repository.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+    return task
+
+
+@router.post("/", response_model=TaskResponse, status_code=status.HTTP_201_CREATED)
+async def create_task(request: TaskRequest, background_tasks: BackgroundTasks) -> TaskResponse:
+    repository = get_task_repository()
+    task = await repository.create_task(request.description)
+    manager = get_sandbox_manager(repository)
+    await manager.launch(task, background_tasks)
+    return task

--- a/backend/buffoon/schemas/AgentState.py
+++ b/backend/buffoon/schemas/AgentState.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from .TaskRequest import TaskStatus
+
+
+class AgentLogEntry(BaseModel):
+    timestamp: float
+    message: str
+
+
+class AgentState(BaseModel):
+    agentId: str
+    taskId: str
+    status: TaskStatus
+    progress: float = Field(ge=0.0, le=1.0)
+    vncUrl: Optional[str] = None
+    logs: List[AgentLogEntry] = Field(default_factory=list)

--- a/backend/buffoon/schemas/TaskRequest.py
+++ b/backend/buffoon/schemas/TaskRequest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaskStatus(str, enum.Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class TaskRequest(BaseModel):
+    description: str = Field(..., min_length=5, max_length=2_000)
+
+
+class TaskResponse(TaskRequest):
+    id: str
+    agentId: str
+    status: TaskStatus
+    createdAt: str
+    updatedAt: str
+    result: Optional[str] = None
+    error: Optional[str] = None
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "id": "1b2d3f",
+                "agentId": "agent-1b2d3f",
+                "description": "Collect the latest FastAPI release notes.",
+                "status": TaskStatus.RUNNING,
+                "createdAt": "2024-01-01T00:00:00+00:00",
+                "updatedAt": "2024-01-01T00:00:00+00:00",
+            }
+        }

--- a/backend/buffoon/services/agent_planner.py
+++ b/backend/buffoon/services/agent_planner.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import List
+
+
+class AgentPlanner:
+    """Generates deterministic task plans for demonstration purposes."""
+
+    def build_plan(self, description: str) -> List[str]:
+        normalized = description.lower()
+        if "research" in normalized:
+            return [
+                "Open documentation portals",
+                "Aggregate relevant references",
+                "Summarize findings into actionable insights",
+            ]
+        if "test" in normalized:
+            return [
+                "Run automated checks",
+                "Capture logs",
+                "Report pass/fail summary",
+            ]
+        return [
+            "Prepare sandbox",
+            "Execute primary task flow",
+            "Persist results",
+        ]
+
+
+def get_planner() -> AgentPlanner:
+    if not hasattr(get_planner, "_instance"):
+        get_planner._instance = AgentPlanner()
+    return get_planner._instance  # type: ignore[attr-defined]

--- a/backend/buffoon/services/agent_state_store.py
+++ b/backend/buffoon/services/agent_state_store.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Dict, Optional
+
+from ..schemas.AgentState import AgentLogEntry, AgentState
+from ..schemas.TaskRequest import TaskStatus
+
+
+class AgentStateStore:
+    def __init__(self) -> None:
+        self._states: Dict[str, AgentState] = {}
+        self._lock = asyncio.Lock()
+
+    async def upsert(self, agent_id: str, task_id: str, status: TaskStatus, message: str) -> AgentState:
+        async with self._lock:
+            state = self._states.get(agent_id)
+            log_entry = AgentLogEntry(timestamp=time.time(), message=message)
+            if state:
+                next_progress = 1.0 if status == TaskStatus.COMPLETED else min(1.0, state.progress + 0.34)
+                updated = state.model_copy(
+                    update={
+                        "status": status,
+                        "logs": [*state.logs, log_entry],
+                        "progress": next_progress,
+                    }
+                )
+                self._states[agent_id] = updated
+                return updated
+            new_state = AgentState(
+                agentId=agent_id,
+                taskId=task_id,
+                status=status,
+                progress=0.1,
+                logs=[log_entry],
+                vncUrl=f"http://localhost:6080/{agent_id}",
+            )
+            self._states[agent_id] = new_state
+            return new_state
+
+    async def get(self, agent_id: str) -> Optional[AgentState]:
+        async with self._lock:
+            return self._states.get(agent_id)
+
+    async def list(self) -> Dict[str, AgentState]:
+        async with self._lock:
+            return dict(self._states)
+
+
+def get_agent_state_store() -> AgentStateStore:
+    if not hasattr(get_agent_state_store, "_instance"):
+        get_agent_state_store._instance = AgentStateStore()
+    return get_agent_state_store._instance  # type: ignore[attr-defined]

--- a/backend/buffoon/services/sandbox_manager.py
+++ b/backend/buffoon/services/sandbox_manager.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from typing import AsyncIterator
+
+from fastapi import BackgroundTasks
+
+from ..backend_utils.logger import structured_log
+from ..schemas.TaskRequest import TaskResponse, TaskStatus
+from .agent_planner import get_planner
+from .agent_state_store import get_agent_state_store
+from .task_repository import TaskRepository
+
+
+class SandboxManager:
+    """Coordinates background execution of sandboxed tasks."""
+
+    def __init__(self, repository: TaskRepository) -> None:
+        self._repository = repository
+        self._agent_states = get_agent_state_store()
+
+    async def launch(self, task: TaskResponse, background_tasks: BackgroundTasks) -> None:
+        background_tasks.add_task(self._run_plan, task.id, task.agentId, task.description)
+
+    async def _run_plan(self, task_id: str, agent_id: str, description: str) -> None:
+        planner = get_planner()
+        plan = planner.build_plan(description)
+        await self._repository.update_task(task_id, status=TaskStatus.RUNNING)
+        await self._agent_states.upsert(agent_id, task_id, TaskStatus.RUNNING, "Sandbox bootstrapped")
+        structured_log("Sandbox started", task_id=task_id, steps=len(plan))
+
+        async for progress, message in self._simulate_execution(plan):
+            status = TaskStatus.COMPLETED if progress >= 1.0 else TaskStatus.RUNNING
+            await self._repository.update_task(
+                task_id,
+                result=message if status == TaskStatus.COMPLETED else None,
+                status=status,
+            )
+            await self._agent_states.upsert(agent_id, task_id, status, message)
+            structured_log("Sandbox heartbeat", task_id=task_id, progress=progress, message=message)
+
+    async def _simulate_execution(self, steps: list[str]) -> AsyncIterator[tuple[float, str]]:
+        for index, step in enumerate(steps, start=1):
+            await asyncio.sleep(random.uniform(0.2, 0.6))
+            yield index / len(steps), f"{step} completed at {time.strftime('%X')}"
+
+
+def get_sandbox_manager(repository: TaskRepository) -> SandboxManager:
+    if not hasattr(get_sandbox_manager, "_instance"):
+        get_sandbox_manager._instance = SandboxManager(repository)
+    return get_sandbox_manager._instance  # type: ignore[attr-defined]

--- a/backend/buffoon/services/task_repository.py
+++ b/backend/buffoon/services/task_repository.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from ..schemas.TaskRequest import TaskResponse, TaskStatus
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class TaskRepository:
+    """In-memory task persistence for the MVP."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[str, TaskResponse] = {}
+        self._lock = asyncio.Lock()
+
+    async def create_task(self, description: str) -> TaskResponse:
+        async with self._lock:
+            task_id = str(uuid.uuid4())
+            now = _timestamp()
+            task = TaskResponse(
+                id=task_id,
+                agentId=f"agent-{task_id[:8]}",
+                description=description,
+                status=TaskStatus.PENDING,
+                createdAt=now,
+                updatedAt=now,
+            )
+            self._tasks[task_id] = task
+            return task
+
+    async def update_task(self, task_id: str, **changes: object) -> Optional[TaskResponse]:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return None
+            updated = task.model_copy(update={**changes, "updatedAt": _timestamp()})
+            self._tasks[task_id] = updated
+            return updated
+
+    async def list_tasks(self) -> List[TaskResponse]:
+        async with self._lock:
+            return list(self._tasks.values())
+
+    async def get_task(self, task_id: str) -> Optional[TaskResponse]:
+        async with self._lock:
+            return self._tasks.get(task_id)
+
+
+def get_task_repository() -> TaskRepository:
+    """Singleton-style accessor to keep shared state during development."""
+    if not hasattr(get_task_repository, "_instance"):
+        get_task_repository._instance = TaskRepository()
+    return get_task_repository._instance  # type: ignore[attr-defined]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from buffoon.routers import agents, health, tasks
+
+app = FastAPI(title="Buffoon Backend", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(health.router)
+app.include_router(tasks.router)
+app.include_router(agents.router)
+
+
+@app.get("/", tags=["meta"])
+async def root():
+    return {"message": "Buffoon backend is online"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.109.0
+uvicorn[standard]==0.25.0
+pydantic==2.5.3
+python-dotenv==1.0.0
+loguru==0.7.2
+httpx==0.25.2

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  backend:
+    image: python:3.11-slim
+    command: bash -c "pip install -r requirements.txt && uvicorn main:app --host 0.0.0.0 --port 8000 --reload"
+    working_dir: /workspace/backend
+    volumes:
+      - ./backend:/workspace/backend
+    ports:
+      - "8000:8000"
+  frontend:
+    image: node:18-alpine
+    command: sh -c "npm install && npm run dev"
+    working_dir: /workspace/frontend
+    volumes:
+      - ./frontend:/workspace/frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_BACKEND_URL=http://localhost:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+services:
+  backend:
+    build:
+      context: ./backend
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - ./backend:/app
+    working_dir: /app
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./.env.example
+  frontend:
+    build:
+      context: ./frontend
+    command: npm run dev
+    volumes:
+      - ./frontend:/app
+    working_dir: /app
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_BACKEND_URL=http://localhost:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+
+CMD ["npm", "run", "dev"]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+  eslint: {
+    dirs: ['src']
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "buffoon-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@geist-ui/core": "2.3.10",
+    "@geist-ui/icons": "1.0.2",
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.5"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.40",
+    "@types/react-dom": "18.2.17",
+    "eslint": "8.56.0",
+    "eslint-config-next": "13.5.6",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/src/components/AgentConsole.tsx
+++ b/frontend/src/components/AgentConsole.tsx
@@ -1,0 +1,52 @@
+import { Card, Code, Dot, Grid, Spacer, Text } from '@geist-ui/core';
+import { TaskResponse } from '../utils/api';
+
+interface AgentConsoleProps {
+  task: TaskResponse;
+}
+
+const statusColor: Record<TaskResponse['status'], 'success' | 'warning' | 'secondary' | 'error'> = {
+  completed: 'success',
+  failed: 'error',
+  pending: 'warning',
+  running: 'secondary'
+};
+
+const statusLabel: Record<TaskResponse['status'], string> = {
+  completed: 'Completed',
+  failed: 'Failed',
+  pending: 'Pending',
+  running: 'Running'
+};
+
+export default function AgentConsole({ task }: AgentConsoleProps) {
+  return (
+    <Card className="status-card" shadow type="dark" aria-live="polite">
+      <Grid.Container gap={0.5} alignItems="center">
+        <Grid xs={24}>
+          <Text h3>{task.description}</Text>
+        </Grid>
+        <Grid xs={24}>
+          <Dot type={statusColor[task.status]}>{statusLabel[task.status]}</Dot>
+        </Grid>
+        <Grid xs={24}>
+          <Text small type="secondary">
+            Agent ID: {task.agentId} • Last updated {new Date(task.updatedAt).toLocaleString()}
+          </Text>
+        </Grid>
+        <Spacer h={1} />
+        {task.result ? (
+          <Grid xs={24}>
+            <Text small type="secondary">Result</Text>
+            <Code block>{task.result}</Code>
+          </Grid>
+        ) : null}
+        {task.error ? (
+          <Grid xs={24}>
+            <Text small type="error">{task.error}</Text>
+          </Grid>
+        ) : null}
+      </Grid.Container>
+    </Card>
+  );
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,47 @@
+import { Grid, Link, Spacer, Text } from '@geist-ui/core';
+
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <Grid.Container gap={2} justify="center">
+        <Grid xs={24} md={12}>
+          <div className="donation-section">
+            <Text h3>Support This Project</Text>
+            <Spacer h={1} />
+            <div className="crypto-addresses">
+              <div className="address-item">
+                <Text small b>ETH/BSC:</Text>
+                <Text small type="secondary">0xBFD25B75E9a742cEC6ea68D06d631f6EF14Cfa82</Text>
+              </div>
+              <Spacer h={0.5} />
+              <div className="address-item">
+                <Text small b>TRX:</Text>
+                <Text small type="secondary">TRat8qcN5zBQL11SMYWpQKD3EGJacMMy2m</Text>
+              </div>
+              <Spacer h={0.5} />
+              <div className="address-item">
+                <Text small b>BTC:</Text>
+                <Text small type="secondary">bc1qww4ky9sj90k93amwmmsulx2hnvlt9fvktw9d05</Text>
+              </div>
+            </div>
+          </div>
+        </Grid>
+        <Grid xs={24}>
+          <Text small type="secondary">
+            © 2024 | <Link href="https://t.me/likhonsheikh" target="_blank">Developer</Link>
+          </Text>
+        </Grid>
+      </Grid.Container>
+      <style jsx>{`
+        .site-footer {
+          margin-top: 4rem;
+          padding: 2rem 0;
+          border-top: 1px solid var(--geist-border);
+        }
+        .donation-section, .copyright-section { text-align: center; }
+        .crypto-addresses { display: flex; flex-direction: column; gap: 0.5rem; align-items: center; }
+        .address-item { display: flex; flex-direction: column; align-items: center; }
+      `}</style>
+    </footer>
+  );
+}

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Button, Card, Grid, Input, Spacer, Text } from '@geist-ui/core';
+import { submitTask } from '../utils/api';
+
+interface TaskFormProps {
+  onSubmitted?: (taskId: string) => void;
+}
+
+export default function TaskForm({ onSubmitted }: TaskFormProps) {
+  const [description, setDescription] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!description.trim()) {
+      setError('A task description is required to run an agent.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const task = await submitTask(description.trim());
+      setDescription('');
+      onSubmitted?.(task.id);
+    } catch (submissionError) {
+      setError(submissionError instanceof Error ? submissionError.message : 'Unknown error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card className="form-section" shadow type="dark">
+      <form onSubmit={handleSubmit} aria-label="task submission form">
+        <Grid.Container gap={2} justify="flex-start">
+          <Grid xs={24}>
+            <Text h2>Launch an Agent Task</Text>
+            <Text type="secondary">
+              Describe the automation you would like the sandboxed agent to perform. Buffoon orchestrates
+              containers, streams results, and maintains full observability.
+            </Text>
+          </Grid>
+          <Grid xs={24}>
+            <Input.Textarea
+              aria-label="Task description"
+              placeholder="e.g. Research the latest FastAPI releases and summarize the changelog."
+              width="100%"
+              value={description}
+              onChange={event => setDescription(event.target.value)}
+              disabled={isSubmitting}
+              minHeight="120px"
+            />
+          </Grid>
+          {error ? (
+            <Grid xs={24}>
+              <Text type="error" role="alert">
+                {error}
+              </Text>
+            </Grid>
+          ) : null}
+          <Grid xs={24}>
+            <Button
+              htmlType="submit"
+              shadow
+              auto
+              loading={isSubmitting}
+              aria-busy={isSubmitting}
+              aria-live="polite"
+            >
+              Queue Task
+            </Button>
+          </Grid>
+        </Grid.Container>
+      </form>
+      <Spacer h={1} />
+      <Text small type="secondary">
+        Agents execute inside dedicated sandbox containers. Buffoon captures stdout/stderr, final artifacts,
+        and heartbeats to keep you informed about long-running workloads.
+      </Text>
+    </Card>
+  );
+}

--- a/frontend/src/components/VNCViewer.tsx
+++ b/frontend/src/components/VNCViewer.tsx
@@ -1,0 +1,37 @@
+import { Card, Grid, Link, Spacer, Text } from '@geist-ui/core';
+
+interface VNCViewerProps {
+  endpoint?: string;
+}
+
+export default function VNCViewer({ endpoint }: VNCViewerProps) {
+  return (
+    <Card className="status-card" shadow type="dark">
+      <Grid.Container gap={1}>
+        <Grid xs={24}>
+          <Text h3>Live Sandbox Session</Text>
+        </Grid>
+        <Grid xs={24}>
+          <Text type="secondary">
+            Buffoon streams interactive browser sessions over WebSockets. Connect using a VNC client or
+            compatible web viewer.
+          </Text>
+        </Grid>
+        <Spacer h={1} />
+        {endpoint ? (
+          <Grid xs={24}>
+            <Link href={endpoint} target="_blank" rel="noopener noreferrer">
+              Open noVNC session
+            </Link>
+          </Grid>
+        ) : (
+          <Grid xs={24}>
+            <Text small type="secondary">
+              Session endpoint will appear when the sandbox container is provisioned.
+            </Text>
+          </Grid>
+        )}
+      </Grid.Container>
+    </Card>
+  );
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,0 +1,17 @@
+import type { AppProps } from 'next/app';
+import { GeistProvider, CssBaseline } from '@geist-ui/core';
+import Head from 'next/head';
+import '../styles/global.css';
+
+export default function BuffoonApp({ Component, pageProps }: AppProps) {
+  return (
+    <GeistProvider>
+      <CssBaseline />
+      <Head>
+        <title>Buffoon Agent Orchestrator</title>
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
+      </Head>
+      <Component {...pageProps} />
+    </GeistProvider>
+  );
+}

--- a/frontend/src/pages/agents/[agentId].tsx
+++ b/frontend/src/pages/agents/[agentId].tsx
@@ -1,0 +1,53 @@
+import { Grid, Loading, Spacer, Text } from '@geist-ui/core';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import Footer from '../../components/Footer';
+import AgentConsole from '../../components/AgentConsole';
+import VNCViewer from '../../components/VNCViewer';
+import { useTask } from '../../utils/api';
+
+export default function AgentDetailPage() {
+  const router = useRouter();
+  const { agentId } = router.query;
+  const taskId = useMemo(() => (typeof agentId === 'string' ? agentId : undefined), [agentId]);
+  const { data, error, isLoading } = useTask(taskId);
+
+  return (
+    <main>
+      <div className="site-container">
+        <Grid.Container gap={2}>
+          <Grid xs={24}>
+            <Text h1>Agent Session</Text>
+            <Text type="secondary">
+              Inspect live logs, streaming updates, and connect to the sandbox browser.
+            </Text>
+          </Grid>
+          {isLoading ? (
+            <Grid xs={24}>
+              <Loading>Loading agent details…</Loading>
+            </Grid>
+          ) : error ? (
+            <Grid xs={24}>
+              <Text type="error">Unable to load agent details: {error.message}</Text>
+            </Grid>
+          ) : data ? (
+            <>
+              <Grid xs={24} md={14}>
+                <AgentConsole task={data} />
+              </Grid>
+              <Grid xs={24} md={10}>
+                <VNCViewer endpoint={data.status === 'running' ? `http://localhost:6080/${data.agentId}` : undefined} />
+              </Grid>
+            </>
+          ) : (
+            <Grid xs={24}>
+              <Text type="secondary">Task not found. Return to the task console to launch a new job.</Text>
+            </Grid>
+          )}
+        </Grid.Container>
+        <Spacer h={3} />
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,0 +1,32 @@
+import { Button, Grid, Spacer, Text } from '@geist-ui/core';
+import Link from 'next/link';
+import Footer from '../components/Footer';
+import TaskForm from '../components/TaskForm';
+
+export default function HomePage() {
+  return (
+    <main>
+      <div className="site-container">
+        <Grid.Container gap={2} alignItems="center">
+          <Grid xs={24} md={16}>
+            <Text h1>Buffoon</Text>
+            <Text h3 type="secondary">
+              Agent orchestration platform that provisions sandbox containers, routes events, and provides
+              full-stack observability for LLM-driven automations.
+            </Text>
+            <Spacer h={1.5} />
+            <Link href="/tasks" legacyBehavior>
+              <Button auto shadow type="success">
+                View Task Console
+              </Button>
+            </Link>
+          </Grid>
+          <Grid xs={24} md={8}>
+            <TaskForm />
+          </Grid>
+        </Grid.Container>
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/frontend/src/pages/tasks.tsx
+++ b/frontend/src/pages/tasks.tsx
@@ -1,0 +1,67 @@
+import { Button, Grid, Loading, Spacer, Table, Text } from '@geist-ui/core';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import Footer from '../components/Footer';
+import TaskForm from '../components/TaskForm';
+import AgentConsole from '../components/AgentConsole';
+import { useTasks } from '../utils/api';
+
+export default function TasksPage() {
+  const router = useRouter();
+  const { data, error, isLoading } = useTasks();
+
+  return (
+    <main>
+      <div className="site-container">
+        <Grid.Container gap={2}>
+          <Grid xs={24}>
+            <Text h1>Task Console</Text>
+            <Text type="secondary">
+              Track each request across its lifecycle. Buffoon emits structured events for every container so you
+              always know what your agents are doing.
+            </Text>
+          </Grid>
+          <Grid xs={24} md={10}>
+            <TaskForm onSubmitted={taskId => router.push(`/agents/${taskId}`)} />
+          </Grid>
+          <Grid xs={24} md={14}>
+            <div role="region" aria-live="polite" aria-busy={isLoading}>
+              {isLoading ? (
+                <Loading>Fetching tasks…</Loading>
+              ) : error ? (
+                <Text type="error">Failed to load tasks: {error.message}</Text>
+              ) : data && data.length > 0 ? (
+                <Table data={data} emptyText="No tasks yet">
+                  <Table.Column prop="description" label="Description" width={240} />
+                  <Table.Column prop="status" label="Status" width={120} />
+                  <Table.Column
+                    prop="agentId"
+                    label="Agent"
+                    render={(value, row) => (
+                      <Link href={`/agents/${row.id}`} legacyBehavior>
+                        <Button auto size="small" type="success" ghost>
+                          Inspect
+                        </Button>
+                      </Link>
+                    )}
+                  />
+                </Table>
+              ) : (
+                <Text type="secondary">Submit a task to begin orchestrating agents.</Text>
+              )}
+            </div>
+          </Grid>
+        </Grid.Container>
+        <Spacer h={3} />
+        <Grid.Container gap={2}>
+          {data?.map(task => (
+            <Grid xs={24} md={12} key={task.id}>
+              <AgentConsole task={task} />
+            </Grid>
+          ))}
+        </Grid.Container>
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,62 @@
+:root {
+  --buffoon-max-width: 1200px;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0b0b0f;
+  color: #f5f5f5;
+}
+
+a {
+  color: inherit;
+}
+
+main {
+  min-height: 100vh;
+}
+
+button {
+  cursor: pointer;
+}
+
+.site-container {
+  max-width: var(--buffoon-max-width);
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.form-section {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.status-card {
+  background: rgba(18, 18, 24, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .site-container {
+    padding: 1.5rem 1rem;
+  }
+
+  .form-section {
+    padding: 1.5rem;
+  }
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,48 @@
+import useSWR, { mutate } from 'swr';
+
+export interface TaskResponse {
+  id: string;
+  description: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  createdAt: string;
+  updatedAt: string;
+  agentId: string;
+  result?: string;
+  error?: string;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'http://localhost:8000';
+
+const fetcher = async <T>(path: string): Promise<T> => {
+  const response = await fetch(`${API_BASE}${path}`);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+};
+
+export const useTasks = () => useSWR<TaskResponse[]>(`/tasks`, path => fetcher<TaskResponse[]>(path));
+
+export const useTask = (taskId?: string) => {
+  const shouldFetch = taskId ? `/tasks/${taskId}` : null;
+  return useSWR<TaskResponse | null>(shouldFetch, path => fetcher<TaskResponse>(path));
+};
+
+export const submitTask = async (description: string) => {
+  const response = await fetch(`${API_BASE}/tasks`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ description })
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Task submission failed');
+  }
+
+  const data = (await response.json()) as TaskResponse;
+  await mutate('/tasks');
+  return data;
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "@types/react"]
+  },
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/shared-types/agent.ts
+++ b/packages/shared-types/agent.ts
@@ -1,0 +1,3 @@
+import type { AgentState } from './index';
+
+export const isAgentComplete = (agent: AgentState): boolean => agent.status === 'completed';

--- a/packages/shared-types/index.ts
+++ b/packages/shared-types/index.ts
@@ -1,0 +1,21 @@
+export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface Task {
+  id: string;
+  agentId: string;
+  description: string;
+  status: TaskStatus;
+  createdAt: string;
+  updatedAt: string;
+  result?: string;
+  error?: string;
+}
+
+export interface AgentState {
+  agentId: string;
+  taskId: string;
+  status: TaskStatus;
+  progress: number;
+  vncUrl?: string;
+  logs: { timestamp: number; message: string }[];
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@buffoon/shared-types",
+  "version": "0.1.0",
+  "main": "index.ts",
+  "types": "index.ts",
+  "license": "MIT"
+}

--- a/packages/utilities/logger.ts
+++ b/packages/utilities/logger.ts
@@ -1,0 +1,16 @@
+import pino from 'pino';
+
+export const logger = pino({
+  name: 'buffoon',
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      colorize: true,
+      translateTime: 'SYS:standard'
+    }
+  }
+});
+
+export const logStructured = (message: string, context: Record<string, unknown> = {}) => {
+  logger.info(context, message);
+};

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@buffoon/utilities",
+  "version": "0.1.0",
+  "main": "logger.ts",
+  "types": "logger.ts",
+  "license": "MIT",
+  "dependencies": {
+    "pino": "8.17.0",
+    "pino-pretty": "10.2.0"
+  }
+}

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY agent_runner.py ./agent_runner.py
+COPY tools ./tools
+
+RUN pip install --no-cache-dir httpx==0.25.2 beautifulsoup4==4.12.2
+
+ENTRYPOINT ["python", "agent_runner.py"]

--- a/sandbox/agent_runner.py
+++ b/sandbox/agent_runner.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+RESULT_PATH = Path(os.environ.get("BUFFOON_RESULT_PATH", "/tmp/buffoon-result.json"))
+
+
+def log(message: str) -> None:
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{timestamp}] {message}")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    payload = {
+        "status": "completed",
+        "summary": "Sandbox executed successfully",
+        "metrics": {"duration_seconds": 1.2},
+    }
+    RESULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with RESULT_PATH.open("w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2)
+    log(f"Result written to {RESULT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/config/sandbox_config.yaml
+++ b/sandbox/config/sandbox_config.yaml
@@ -1,0 +1,4 @@
+image: python:3.11-slim
+workdir: /app
+result_path: /tmp/buffoon-result.json
+max_execution_seconds: 300

--- a/sandbox/config/tool_registry.json
+++ b/sandbox/config/tool_registry.json
@@ -1,0 +1,5 @@
+{
+  "browser": ["sandbox.tools.browser.navigate.fetch_page", "sandbox.tools.browser.extract.extract_links"],
+  "file": ["sandbox.tools.file.read.read_text", "sandbox.tools.file.write.write_text"],
+  "shell": ["sandbox.tools.shell.execute.run_command", "sandbox.tools.shell.list_dir.list_directory"]
+}

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python agent_runner.py "$@"

--- a/sandbox/tools/browser/click.py
+++ b/sandbox/tools/browser/click.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import asyncio
+
+
+async def simulate_click(selector: str) -> str:
+    await asyncio.sleep(0.1)
+    return f"Clicked {selector}"

--- a/sandbox/tools/browser/extract.py
+++ b/sandbox/tools/browser/extract.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+
+def extract_links(html: str) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    return [link.get("href", "") for link in soup.find_all("a") if link.get("href")]

--- a/sandbox/tools/browser/navigate.py
+++ b/sandbox/tools/browser/navigate.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+
+async def fetch_page(url: str, timeout: Optional[float] = 10.0) -> str:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text

--- a/sandbox/tools/file/read.py
+++ b/sandbox/tools/file/read.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_text(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")

--- a/sandbox/tools/file/write.py
+++ b/sandbox/tools/file/write.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_text(path: str, content: str) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(content, encoding="utf-8")

--- a/sandbox/tools/shell/execute.py
+++ b/sandbox/tools/shell/execute.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Sequence
+
+
+async def run_command(command: Sequence[str]) -> tuple[int, str, str]:
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    return process.returncode, stdout.decode(), stderr.decode()

--- a/sandbox/tools/shell/list_dir.py
+++ b/sandbox/tools/shell/list_dir.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+def list_directory(path: str) -> List[str]:
+    return [item.name for item in Path(path).iterdir()]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose build

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose -f docker-compose.yml up --build -d

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose -f docker-compose.dev.yml up --build


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with task, agent, and health routers plus sandbox coordination services
- add Next.js Geist-based frontend for task submission and live agent monitoring views
- introduce sandbox container utilities, shared TypeScript packages, Docker Compose setup, and developer scripts

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_b_68e158b0143c8329b237917e0259dfb8