### PR TITLE
Fix TaskForm submission typing

### DIFF
--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { Button, Card, Grid, Input, Spacer, Text } from '@geist-ui/core';
 import { submitTask } from '../utils/api';
 
@@ -11,7 +11,7 @@ export default function TaskForm({ onSubmitted }: TaskFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!description.trim()) {
       setError('A task description is required to run an agent.');


### PR DESCRIPTION
## Summary
- import the FormEvent type from React for the task submission form
- update the TaskForm submit handler to use the imported FormEvent type instead of the global React namespace

## Testing
- npm install --legacy-peer-deps *(fails: no matching version for @geist-ui/core@2.3.10)*

------
https://chatgpt.com/codex/tasks/task_b_68e17b3dbef48329a3cf5966082da9a6